### PR TITLE
Sync upstream prelude changes from Buck2

### DIFF
--- a/bundles/buckal/cargo_buildscript.bzl
+++ b/bundles/buckal/cargo_buildscript.bzl
@@ -84,7 +84,7 @@ def _make_rustc_shim(ctx: AnalysisContext, cwd: Artifact) -> cmd_args:
         sysroot_args = cmd_args()
 
     shim = cmd_script(
-        ctx = ctx,
+        actions = ctx.actions,
         name = "__rustc_shim",
         cmd = cmd_args(toolchain_info.compiler, sysroot_args, relative_to = cwd),
         language = ctx.attrs._exec_os_type[OsLookup].script,


### PR DESCRIPTION
This PR syncs the latest breaking changes (https://github.com/facebook/buck2/commit/579f766ed7480c9be7e3d622d5f986660c20c10a) from the upstream Buck2 repository introduced yesterday, ensuring compatibility with the updated prelude.