### PR TITLE
fix(ci): re-download Buck2 when version is latest

### DIFF
--- a/.github/actions/install-buck2/action.yml
+++ b/.github/actions/install-buck2/action.yml
@@ -28,7 +28,7 @@ runs:
 
         echo "Downloading buck2 from $URL"
         mkdir -p "$HOME/.cargo/bin"
-        if [ ! -x "$HOME/.cargo/bin/buck2" ]; then
+        if [ "$VERSION" = "latest" ] || [ ! -x "$HOME/.cargo/bin/buck2" ]; then
           curl -fsSL "$URL" | zstd -d -o "$HOME/.cargo/bin/buck2"
           chmod +x "$HOME/.cargo/bin/buck2"
         else
@@ -54,7 +54,7 @@ runs:
         $buck2Exe = "$binDir\buck2.exe"
 
         Write-Host "Downloading buck2 from $buck2Url"
-        if (-not (Test-Path $buck2Exe)) {
+        if (($version -eq "latest") -or (-not (Test-Path $buck2Exe))) {
           Invoke-WebRequest -Uri $buck2Url -OutFile $zstFile
 
           if (-not (Get-Command zstd -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
## Summary
- Force a fresh Buck2 download whenever `version` is `latest` so CI doesn’t stick to a cached older binary.

## Context
The PR #54 [Copilot review](https://github.com/buck2hub/cargo-buckal/pull/54#discussion_r2725518550) noted that caching can pin `latest` to a stale Buck2; this change ensures a fresh download in that case.

---
Parts of this PR were generated with Codex (with `gpt-5.2-codex`). I have conducted a full manual review and take final responsibility for the integrity of the code.