### PR TITLE
fix: use mode = "reference" in export_file for workspace Cargo.toml

### DIFF
--- a/src/buck.rs
+++ b/src/buck.rs
@@ -92,6 +92,8 @@ pub struct CargoManifest {
 pub struct ExportFile {
     pub name: String,
     pub src: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
     pub visibility: Set<String>,
 }
 
@@ -835,10 +837,12 @@ impl ExportFile {
     fn from_kwargs(kwargs: &RuleKwargs) -> anyhow::Result<Self> {
         let name = kwargs.get_str("name")?;
         let src = kwargs.get_str("src")?;
+        let mode = kwargs.get_str_opt("mode");
         let visibility = kwargs.get_list("visibility");
         Ok(ExportFile {
             name,
             src,
+            mode,
             visibility,
         })
     }
@@ -1725,6 +1729,7 @@ mod tests {
         let expected = Rule::ExportFile(ExportFile {
             name: "workspace".to_string(),
             src: "Cargo.toml".to_string(),
+            mode: Some("reference".to_string()),
             visibility: Set::from(["PUBLIC".to_string()]),
         });
         let actual = rules

--- a/src/buckify/actions.rs
+++ b/src/buckify/actions.rs
@@ -119,7 +119,11 @@ impl BuckalChange {
                 Vec::new()
             };
             let export_file = Rule::ExportFile(emit_export_file());
-            if !rules.contains(&export_file) {
+            if let Some(existing) = rules.iter_mut().find(|r| {
+                matches!(r, Rule::ExportFile(ef) if ef.name == "workspace")
+            }) {
+                *existing = export_file;
+            } else {
                 rules.push(export_file);
             }
             let buck_content = gen_buck_content(&rules);

--- a/src/buckify/actions.rs
+++ b/src/buckify/actions.rs
@@ -119,9 +119,10 @@ impl BuckalChange {
                 Vec::new()
             };
             let export_file = Rule::ExportFile(emit_export_file());
-            if let Some(existing) = rules.iter_mut().find(|r| {
-                matches!(r, Rule::ExportFile(ef) if ef.name == "workspace")
-            }) {
+            if let Some(existing) = rules
+                .iter_mut()
+                .find(|r| matches!(r, Rule::ExportFile(ef) if ef.name == "workspace"))
+            {
                 *existing = export_file;
             } else {
                 rules.push(export_file);

--- a/src/buckify/emit.rs
+++ b/src/buckify/emit.rs
@@ -348,11 +348,16 @@ pub(super) fn emit_cargo_manifest(node: &BuckalNode, ctx: &BuckalContext) -> Car
     }
 }
 
-/// Emit `export_file` rule for the workspace Cargo.toml
+/// Emit `export_file` rule for the workspace Cargo.toml.
+///
+/// Uses `mode = "reference"` so that downstream rules (e.g. `cargo_manifest`)
+/// see the real on-disk path instead of a buck-out copy. This is required for
+/// manifest_parse to resolve relative readme/license-file paths correctly.
 pub(super) fn emit_export_file() -> ExportFile {
     ExportFile {
         name: "workspace".to_owned(),
         src: "Cargo.toml".to_string(),
+        mode: Some("reference".to_owned()),
         visibility: Set::from(["PUBLIC".to_owned()]),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub const RUST_CRATES_ROOT: &str = "third-party/rust/crates";
 pub const RUST_GIT_ROOT: &str = "third-party/rust/git";
 pub const BUCKAL_BUNDLES_REPO: &str = "buck2hub/buckal-bundles";
 // fallback commit hash used when fetching the latest from BUCKAL_BUNDLES_REPO fails
-pub const DEFAULT_BUNDLE_HASH: &str = "8d30857f71a6cfcc84e486ff326b990af9212084";
+pub const DEFAULT_BUNDLE_HASH: &str = "221b613c564f7a1b33b4588d33d3a92779eb2d8d";
 
 pub fn build_version() -> &'static str {
     static VERSION_STRING: OnceLock<String> = OnceLock::new();

--- a/testcases/single_export_file.BUCK
+++ b/testcases/single_export_file.BUCK
@@ -1,5 +1,6 @@
 export_file(
     name = 'workspace',
     src = 'Cargo.toml',
+    mode = 'reference',
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
## Summary

  - Emit `mode = "reference"` on the workspace `export_file` rule so downstream rules see the real on-disk path instead
  of a buck-out copy. This is required for `manifest_parse.py` to resolve relative `readme` and `license-file` paths
  correctly against the actual workspace directory.
  - Fix duplicate `export_file` on re-migration: the virtual workspace codepath compared the full rule struct via
  `PartialEq`, so the old rule (no `mode`) and the new one (`mode = "reference"`) were never equal, causing a second
  copy to be appended. Now matches by rule name and replaces in-place.

  Companion to buck2hub/buckal-bundles#10 which updates `manifest_parse.py` to emit absolute paths for
  readme/license-file.

## Test plan

  - [x] Unit tests pass (`cargo test` — 121 passed)
  - [x] `cargo clippy --all-targets --all-features -- -D warnings` clean