### PR TITLE
feat: implement dependency patch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Common commands:
 
 - `cargo buckal init|new`: Create a new package or a Buck2 project in the directory.
 - `cargo buckal migrate`: Migrate an existing Cargo project to Buck2 (generate/update BUCK files).
-- `cargo buckal add|remove|update`: Manage dependencies, applying the changes to both `Cargo.toml` and `BUCK` files.
+- `cargo buckal add|remove|update|patch`: Manage dependencies, applying the changes to both `Cargo.toml`/`buckal.toml` and `BUCK` files.
 - `cargo buckal build`: Build the current package with Buck2.
 - `cargo buckal test`: Compile and execute unit and integration tests with Buck2.
 - `cargo buckal clean`: Remove `buck-out` directory.
@@ -72,6 +72,16 @@ buck2_binary = "/path/to/your/buck2"
 ```
 
 If no configuration file exists, cargo-buckal will use `buck2` (searches your PATH).
+
+To redirect dependency labels from one resolved version to another, add entries to the repo-local
+`buckal.toml`:
+
+```toml
+[patch.version]
+pyo3 = { from = "0.26.0", to = "0.27.2" }
+```
+
+You can also write these entries with `cargo buckal patch pyo3@0.27.2`.
 
 ## Pre-commit Hooks
 

--- a/src/buckify/deps.rs
+++ b/src/buckify/deps.rs
@@ -91,7 +91,12 @@ fn resolve_buckal_name(
     }
 }
 
-fn resolve_dep_label(dep: &BuckalDep, dep_node: &BuckalNode) -> Result<(String, Option<String>)> {
+fn resolve_dep_label(
+    dep: &BuckalDep,
+    dep_node: &BuckalNode,
+    ctx: &BuckalContext,
+) -> Result<(String, Option<String>)> {
+    let dep_node = ctx.patched_node(dep_node)?;
     let dep_package_name = dep_node.name.to_string();
     let is_renamed = dep.name != dep_package_name.replace("-", "_");
     let alias = if is_renamed {
@@ -244,7 +249,7 @@ pub(super) fn set_deps(
             continue;
         }
 
-        let (target_label, alias) = resolve_dep_label(dep, dep_node).with_context(|| {
+        let (target_label, alias) = resolve_dep_label(dep, dep_node, ctx).with_context(|| {
             format!(
                 "failed to resolve dependency label for '{}' (package '{}')",
                 dep.name, dep_node.name
@@ -263,6 +268,17 @@ pub(super) fn set_deps(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    use cargo_metadata::{DependencyKind, Edition, PackageId, camino::Utf8PathBuf};
+    use daggy::Dag;
+
+    use crate::{
+        buck::{CargoTargetKind, RustLibrary},
+        config::{RepoConfig, RepoPatchConfig, VersionPatch},
+        context::BuckalContext,
+        resolve::{BuckalDep, BuckalDepKind, BuckalResolve, NodeKind},
+    };
 
     fn mock_target(name: &str, kind: TargetKind) -> BuckalTarget {
         BuckalTarget {
@@ -296,5 +312,122 @@ mod tests {
 
         let name = resolve_buckal_name(&bin_targets, &lib_targets);
         assert_eq!(name, "foo");
+    }
+
+    #[test]
+    fn test_set_deps_redirects_to_patched_version() {
+        let root_id = PackageId {
+            repr: "path+file:///tmp/root#root@0.1.0".to_string(),
+        };
+        let old_id = PackageId {
+            repr: "registry+https://github.com/rust-lang/crates.io-index#foo@0.1.0".to_string(),
+        };
+        let new_id = PackageId {
+            repr: "registry+https://github.com/rust-lang/crates.io-index#foo@0.2.0".to_string(),
+        };
+
+        let root_node = BuckalNode {
+            package_id: root_id.clone(),
+            name: "root".to_string(),
+            version: "0.1.0".to_string(),
+            features: vec![],
+            kind: NodeKind::FirstParty {
+                relative_path: "".to_string(),
+            },
+            edition: Edition::E2021,
+            manifest_path: Utf8PathBuf::from("/tmp/root/Cargo.toml"),
+            targets: vec![mock_target("root", TargetKind::Lib)],
+            source: None,
+            links: None,
+            checksum: None,
+        };
+
+        let old_node = BuckalNode {
+            package_id: old_id.clone(),
+            name: "foo".to_string(),
+            version: "0.1.0".to_string(),
+            features: vec![],
+            kind: NodeKind::ThirdParty,
+            edition: Edition::E2021,
+            manifest_path: Utf8PathBuf::from("/tmp/vendor/foo/0.1.0/Cargo.toml"),
+            targets: vec![mock_target("foo", TargetKind::Lib)],
+            source: Some("registry+https://github.com/rust-lang/crates.io-index".to_string()),
+            links: None,
+            checksum: None,
+        };
+
+        let new_node = BuckalNode {
+            package_id: new_id.clone(),
+            name: "foo".to_string(),
+            version: "0.2.0".to_string(),
+            features: vec![],
+            kind: NodeKind::ThirdParty,
+            edition: Edition::E2021,
+            manifest_path: Utf8PathBuf::from("/tmp/vendor/foo/0.2.0/Cargo.toml"),
+            targets: vec![mock_target("foo", TargetKind::Lib)],
+            source: Some("registry+https://github.com/rust-lang/crates.io-index".to_string()),
+            links: None,
+            checksum: None,
+        };
+
+        let mut dag = Dag::new();
+        let root_idx = dag.add_node(root_node);
+        let old_idx = dag.add_node(old_node);
+        let new_idx = dag.add_node(new_node);
+
+        dag.add_edge(
+            root_idx,
+            old_idx,
+            BuckalDep {
+                name: "foo".to_string(),
+                dep_kinds: vec![BuckalDepKind {
+                    kind: DependencyKind::Normal,
+                    target: None,
+                }],
+            },
+        )
+        .expect("failed to add edge");
+
+        let mut index_map = HashMap::new();
+        index_map.insert(root_id.clone(), root_idx);
+        index_map.insert(old_id, old_idx);
+        index_map.insert(new_id, new_idx);
+
+        let ctx = BuckalContext {
+            root: Some(root_id.clone()),
+            resolve: BuckalResolve { dag, index_map },
+            workspace_root: Utf8PathBuf::from("/tmp/root"),
+            workspace_inherit: false,
+            no_merge: false,
+            repo_config: RepoConfig {
+                patch: RepoPatchConfig {
+                    version: [(
+                        "foo".to_string(),
+                        VersionPatch {
+                            from: "0.1.0".to_string(),
+                            to: "0.2.0".to_string(),
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+                ..RepoConfig::default()
+            },
+        };
+
+        let root = ctx.resolve.get(&root_id).expect("missing root node");
+        let mut rule = RustLibrary::default();
+
+        set_deps(&mut rule, root, CargoTargetKind::Lib, &ctx).expect("failed to set deps");
+
+        assert!(
+            rule.deps
+                .contains("//third-party/rust/crates/foo/0.2.0:foo")
+        );
+        assert!(
+            !rule
+                .deps
+                .contains("//third-party/rust/crates/foo/0.1.0:foo")
+        );
     }
 }

--- a/src/buckify/emit.rs
+++ b/src/buckify/emit.rs
@@ -227,6 +227,9 @@ pub(super) fn emit_buildscript_run(
     // Set environment variables from dependencies that have the `links` manifest key.
     // See https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
     for (dep, dep_node) in ctx.resolve.deps_of(&node.package_id) {
+        let dep_node = ctx
+            .patched_node(dep_node)
+            .unwrap_or_exit_ctx("failed to resolve patched dependency");
         if dep_node.links.is_some()
             && dep.dep_kinds.iter().any(|dk: &BuckalDepKind| {
                 dep_kind_matches(CargoTargetKind::Lib, dk.kind)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::buckal_error;
 use crate::utils::{UnwrapOrExit, get_cache_path};
 
+use crate::config::RepoPatchConfig;
 use crate::resolve::BuckalResolve;
 
 // type Fingerprint = [u8; 32];
@@ -15,11 +16,12 @@ use crate::resolve::BuckalResolve;
 ///
 /// Version 2: Added multi-platform support to the cache format.
 /// Version 3: Switched to BuckalNode-based fingerprinting (DAG refactor).
+/// Version 4: Include version patch config in fingerprints.
 ///
 /// Migration strategy:
 /// - If found < expected (stale cache from older Buckal): ignore the old cache and rebuild.
 /// - If found > expected (cache from newer Buckal): exit immediately and prompt the user to upgrade.
-const CACHE_VERSION: u32 = 3;
+const CACHE_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Fingerprint([u8; 32]);
@@ -105,13 +107,17 @@ pub struct BuckalCache {
 }
 
 impl BuckalCache {
-    pub fn from_resolve(resolve: &BuckalResolve, workspace_root: &Utf8PathBuf) -> Self {
+    pub fn from_resolve(
+        resolve: &BuckalResolve,
+        workspace_root: &Utf8PathBuf,
+        patch_config: &RepoPatchConfig,
+    ) -> Self {
         let fingerprints = resolve
             .nodes()
             .map(|node| {
                 (
                     node.package_id.canonicalize(workspace_root),
-                    resolve.fingerprint_of(&node.package_id, workspace_root),
+                    resolve.fingerprint_of(&node.package_id, workspace_root, patch_config),
                 )
             })
             .collect();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,9 @@ pub enum BuckalSubCommands {
     /// Create a new package
     New(crate::commands::new::NewArgs),
 
+    /// Patch dependency labels to a different resolved version
+    Patch(crate::commands::patch::PatchArgs),
+
     /// Push third-party BUCK files to a registry
     Push(crate::commands::push::PushArgs),
 
@@ -88,6 +91,7 @@ impl Cli {
                         BuckalSubCommands::Logout(args) => commands::logout::execute(args),
                         BuckalSubCommands::Migrate(args) => commands::migrate::execute(args),
                         BuckalSubCommands::New(args) => commands::new::execute(args),
+                        BuckalSubCommands::Patch(args) => commands::patch::execute(args),
                         BuckalSubCommands::Push(args) => commands::push::execute(args),
                         BuckalSubCommands::Remove(args) => commands::remove::execute(args),
                         BuckalSubCommands::Test(args) => commands::test::execute(args),
@@ -218,6 +222,21 @@ mod tests {
                     assert!(err.to_string().contains("not a valid rustc target"));
                 }
                 other => panic!("expected test subcommand, got {other:?}"),
+            },
+        }
+    }
+
+    #[test]
+    fn test_cli_patch_accepts_package_spec() {
+        let cli = Cli::try_parse_from(["cargo", "buckal", "patch", "pyo3@0.27.2"])
+            .expect("failed to parse patch args");
+
+        match cli.command {
+            Commands::Buckal(args) => match args.subcommands {
+                Some(BuckalSubCommands::Patch(patch_args)) => {
+                    assert_eq!(patch_args.package, "pyo3@0.27.2");
+                }
+                other => panic!("expected patch subcommand, got {other:?}"),
             },
         }
     }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -69,7 +69,8 @@ pub fn execute(args: &AddArgs) {
 
     let ctx = BuckalContext::new(args.manifest_path.clone());
 
-    let new_cache = BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root);
+    let new_cache =
+        BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root, &ctx.repo_config.patch);
     let changes = new_cache.diff(&last_cache, &ctx.workspace_root);
 
     changes.apply(&ctx);

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -122,7 +122,8 @@ pub fn execute(args: &MigrateArgs) {
     } else {
         BuckalCache::load().unwrap_or_exit_ctx("failed to load existing cache")
     };
-    let new_cache = BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root);
+    let new_cache =
+        BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root, &ctx.repo_config.patch);
     let changes = new_cache.diff(&last_cache, &ctx.workspace_root);
 
     // Apply changes to BUCK files

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod login;
 pub mod logout;
 pub mod migrate;
 pub mod new;
+pub mod patch;
 pub mod push;
 pub mod remove;
 pub mod test;

--- a/src/commands/patch.rs
+++ b/src/commands/patch.rs
@@ -1,0 +1,368 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fs;
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Parser;
+use semver::Version;
+use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
+
+use crate::{
+    buckal_log,
+    cache::{BuckalCache, BuckalChange, ChangeType},
+    config::{RepoConfig, VersionPatch},
+    context::BuckalContext,
+    resolve::{BuckalNode, NodeKind},
+    utils::{UnwrapOrExit, ensure_prerequisites, section},
+};
+
+#[derive(Parser, Debug)]
+pub struct PatchArgs {
+    /// Dependency to patch, optionally pinned to the version to keep
+    #[arg(value_name = "SPEC")]
+    pub package: String,
+
+    /// Path to Cargo.toml
+    #[arg(long)]
+    pub manifest_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectedPatch {
+    name: String,
+    version_patch: VersionPatch,
+}
+
+pub fn execute(args: &PatchArgs) {
+    ensure_prerequisites().unwrap_or_exit();
+
+    let mut ctx = BuckalContext::new(args.manifest_path.clone());
+    let selected = select_patch_for_spec(&ctx, &args.package)
+        .unwrap_or_exit_ctx("failed to determine dependency patch");
+
+    // Compute targeted BUCK changes before persisting to buckal.toml so that
+    // a failure here does not leave a partially-written config file.
+    let changes = targeted_patch_changes(&ctx, &selected)
+        .unwrap_or_exit_ctx("failed to compute patched BUCK updates");
+
+    upsert_version_patch(
+        &RepoConfig::repo_config_path(),
+        &selected.name,
+        &selected.version_patch,
+    )
+    .unwrap_or_exit_ctx("failed to update buckal.toml");
+
+    // Update the in-memory config so label emission and cache use the new patch.
+    ctx.repo_config
+        .patch
+        .version
+        .insert(selected.name.clone(), selected.version_patch.clone());
+
+    section("Buckal Console");
+    buckal_log!(
+        "Patching",
+        format!(
+            "{} {} -> {}",
+            selected.name, selected.version_patch.from, selected.version_patch.to
+        )
+    );
+
+    changes.apply(&ctx);
+    BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root, &ctx.repo_config.patch).save();
+}
+
+fn select_patch_for_spec(ctx: &BuckalContext, spec: &str) -> Result<SelectedPatch> {
+    let (name, requested_to) = parse_package_spec(spec);
+    let versions = collect_third_party_versions(ctx, name);
+
+    if versions.len() < 2 {
+        bail!(
+            "dependency '{}' only has one resolved third-party version ({})",
+            name,
+            versions.join(", ")
+        );
+    }
+
+    let version_patch = if let Some(requested_to) = requested_to {
+        if !versions.iter().any(|version| version == requested_to) {
+            bail!(
+                "dependency '{}' does not resolve version '{}'; available versions: {}",
+                name,
+                requested_to,
+                versions.join(", ")
+            );
+        }
+
+        let from_versions: Vec<_> = versions
+            .iter()
+            .filter(|version| version.as_str() != requested_to)
+            .cloned()
+            .collect();
+
+        if from_versions.len() != 1 {
+            bail!(
+                "dependency '{}' resolves multiple source versions ({}); specify a unique target by first reducing the graph to exactly two versions",
+                name,
+                versions.join(", ")
+            );
+        }
+
+        VersionPatch {
+            from: from_versions[0].clone(),
+            to: requested_to.to_string(),
+        }
+    } else {
+        if versions.len() != 2 {
+            bail!(
+                "dependency '{}' resolves {} versions ({}); specify the version to keep as '{}@<VERSION>'",
+                name,
+                versions.len(),
+                versions.join(", "),
+                name
+            );
+        }
+
+        VersionPatch {
+            from: versions[0].clone(),
+            to: versions[1].clone(),
+        }
+    };
+
+    Ok(SelectedPatch {
+        name: name.to_string(),
+        version_patch,
+    })
+}
+
+fn collect_third_party_versions(ctx: &BuckalContext, name: &str) -> Vec<String> {
+    let mut versions: Vec<String> = ctx
+        .resolve
+        .nodes()
+        .filter(|node| matches!(node.kind, NodeKind::ThirdParty) && node.name == name)
+        .map(|node| node.version.clone())
+        .collect();
+
+    versions.sort_by(|a, b| version_cmp(a, b));
+    versions.dedup();
+    versions
+}
+
+fn targeted_patch_changes(ctx: &BuckalContext, selected: &SelectedPatch) -> Result<BuckalChange> {
+    let from_node = find_unique_third_party_node(
+        ctx.resolve.nodes(),
+        &selected.name,
+        &selected.version_patch.from,
+    )?;
+    let to_node = find_unique_third_party_node(
+        ctx.resolve.nodes(),
+        &selected.name,
+        &selected.version_patch.to,
+    )?;
+
+    let mut changes = BTreeMap::new();
+    changes.insert(to_node.package_id.clone(), ChangeType::Changed);
+
+    for dependent in ctx.resolve.dependents(&from_node.package_id) {
+        changes.insert(dependent.package_id.clone(), ChangeType::Changed);
+    }
+
+    Ok(BuckalChange { changes })
+}
+
+fn find_unique_third_party_node<'a>(
+    nodes: impl Iterator<Item = &'a BuckalNode>,
+    name: &str,
+    version: &str,
+) -> Result<&'a BuckalNode> {
+    let matches: Vec<&BuckalNode> = nodes
+        .filter(|node| {
+            matches!(node.kind, NodeKind::ThirdParty)
+                && node.name == name
+                && node.version == version
+        })
+        .collect();
+
+    match matches.as_slice() {
+        [node] => Ok(*node),
+        [] => Err(anyhow!(
+            "dependency '{}' version '{}' was not found in the resolved graph",
+            name,
+            version
+        )),
+        _ => Err(anyhow!(
+            "dependency '{}' version '{}' is ambiguous in the resolved graph",
+            name,
+            version
+        )),
+    }
+}
+
+fn upsert_version_patch(
+    repo_config_path: &std::path::Path,
+    dep_name: &str,
+    patch: &VersionPatch,
+) -> Result<()> {
+    let mut doc = if repo_config_path.exists() {
+        fs::read_to_string(repo_config_path)
+            .with_context(|| format!("failed to read {}", repo_config_path.display()))?
+            .parse::<DocumentMut>()
+            .with_context(|| format!("failed to parse {}", repo_config_path.display()))?
+    } else {
+        DocumentMut::new()
+    };
+
+    insert_version_patch(&mut doc, dep_name, patch)?;
+
+    fs::write(repo_config_path, doc.to_string())
+        .with_context(|| format!("failed to write {}", repo_config_path.display()))?;
+    Ok(())
+}
+
+fn insert_version_patch(doc: &mut DocumentMut, dep_name: &str, patch: &VersionPatch) -> Result<()> {
+    let patch_item = doc.entry("patch").or_insert(Item::Table(Table::new()));
+    let Some(patch_table) = patch_item.as_table_mut() else {
+        bail!("[patch] must be a table");
+    };
+
+    if !patch_table.contains_key("version") {
+        patch_table.insert("version", Item::Table(Table::new()));
+    }
+
+    let Some(version_table) = patch_table["version"].as_table_mut() else {
+        bail!("[patch.version] must be a table");
+    };
+
+    let mut inline = InlineTable::new();
+    inline.insert("from", Value::from(patch.from.clone()));
+    inline.insert("to", Value::from(patch.to.clone()));
+    version_table.insert(dep_name, Item::Value(Value::InlineTable(inline)));
+    Ok(())
+}
+
+fn parse_package_spec(spec: &str) -> (&str, Option<&str>) {
+    if let Some((name, version)) = spec.split_once('@') {
+        (name, Some(version))
+    } else {
+        (spec, None)
+    }
+}
+
+fn version_cmp(left: &str, right: &str) -> Ordering {
+    match (Version::parse(left), Version::parse(right)) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_ctx(name: &str, versions: &[&str]) -> BuckalContext {
+        use std::collections::HashMap;
+
+        use cargo_metadata::{Edition, PackageId, TargetKind, camino::Utf8PathBuf};
+        use daggy::Dag;
+
+        use crate::{
+            config::RepoPatchConfig,
+            resolve::{BuckalResolve, BuckalTarget},
+        };
+
+        let mut dag = Dag::new();
+        let mut index_map = HashMap::new();
+
+        for version in versions {
+            let node = BuckalNode {
+                package_id: PackageId {
+                    repr: format!(
+                        "registry+https://github.com/rust-lang/crates.io-index#{name}@{version}"
+                    ),
+                },
+                name: name.to_string(),
+                version: (*version).to_string(),
+                features: vec![],
+                kind: NodeKind::ThirdParty,
+                edition: Edition::E2021,
+                manifest_path: Utf8PathBuf::from(format!("/tmp/{name}/{version}/Cargo.toml")),
+                targets: vec![BuckalTarget {
+                    name: name.to_string(),
+                    kind: vec![TargetKind::Lib],
+                    src_path: Utf8PathBuf::from(format!("/tmp/{name}/{version}/src/lib.rs")),
+                    doctest: true,
+                    test: true,
+                }],
+                source: Some("registry+https://github.com/rust-lang/crates.io-index".to_string()),
+                links: None,
+                checksum: None,
+            };
+            let pkg_id = node.package_id.clone();
+            let idx = dag.add_node(node);
+            index_map.insert(pkg_id, idx);
+        }
+
+        BuckalContext {
+            root: None,
+            resolve: BuckalResolve { dag, index_map },
+            workspace_root: Utf8PathBuf::from("/tmp/workspace"),
+            workspace_inherit: false,
+            no_merge: false,
+            repo_config: RepoConfig {
+                patch: RepoPatchConfig::default(),
+                ..RepoConfig::default()
+            },
+        }
+    }
+
+    #[test]
+    fn test_select_patch_without_explicit_target_uses_higher_version() {
+        let ctx = mock_ctx("pyo3", &["0.26.0", "0.27.2"]);
+
+        let selected = select_patch_for_spec(&ctx, "pyo3").expect("failed to select patch");
+
+        assert_eq!(
+            selected.version_patch,
+            VersionPatch {
+                from: "0.26.0".to_string(),
+                to: "0.27.2".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_select_patch_with_explicit_target_version() {
+        let ctx = mock_ctx("pyo3", &["0.26.0", "0.27.2"]);
+
+        let selected = select_patch_for_spec(&ctx, "pyo3@0.27.2").expect("failed to select patch");
+
+        assert_eq!(selected.version_patch.from, "0.26.0");
+        assert_eq!(selected.version_patch.to, "0.27.2");
+    }
+
+    #[test]
+    fn test_select_patch_requires_unique_other_version() {
+        let ctx = mock_ctx("pyo3", &["0.25.0", "0.26.0", "0.27.2"]);
+
+        let err = select_patch_for_spec(&ctx, "pyo3@0.27.2").expect_err("expected ambiguity");
+
+        assert!(
+            err.to_string()
+                .contains("resolves multiple source versions")
+        );
+    }
+
+    #[test]
+    fn test_insert_version_patch_writes_expected_shape() {
+        let mut doc = DocumentMut::new();
+        let patch = VersionPatch {
+            from: "0.26.0".to_string(),
+            to: "0.27.2".to_string(),
+        };
+
+        insert_version_patch(&mut doc, "pyo3", &patch).unwrap();
+
+        let rendered = doc.to_string();
+        assert!(rendered.contains("[patch.version]"));
+        assert!(rendered.contains("pyo3 = { from = \"0.26.0\", to = \"0.27.2\" }"));
+    }
+}

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -62,7 +62,8 @@ pub fn execute(args: &RemoveArgs) {
 
     let ctx = BuckalContext::new(args.manifest_path.clone());
 
-    let new_cache = BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root);
+    let new_cache =
+        BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root, &ctx.repo_config.patch);
     let changes = new_cache.diff(&last_cache, &ctx.workspace_root);
 
     changes.apply(&ctx);

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -51,7 +51,8 @@ pub fn execute(args: &UpdateArgs) {
 
     let ctx = BuckalContext::new(args.manifest_path.clone());
 
-    let new_cache = BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root);
+    let new_cache =
+        BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root, &ctx.repo_config.patch);
     let changes = new_cache.diff(&last_cache, &ctx.workspace_root);
 
     changes.apply(&ctx);

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,6 +166,7 @@ pub struct RepoConfig {
     pub align_cells: bool,
     pub ignore_tests: bool,
     pub patch_fields: Set<String>,
+    pub patch: RepoPatchConfig,
 }
 
 impl Default for RepoConfig {
@@ -174,8 +175,22 @@ impl Default for RepoConfig {
             align_cells: false,
             ignore_tests: true,
             patch_fields: Set::new(),
+            patch: RepoPatchConfig::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RepoPatchConfig {
+    #[serde(skip_serializing_if = "Map::is_empty")]
+    pub version: Map<String, VersionPatch>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VersionPatch {
+    pub from: String,
+    pub to: String,
 }
 
 impl RepoConfig {
@@ -210,5 +225,30 @@ impl RepoConfig {
     pub fn repo_config_path() -> PathBuf {
         let buck2_root = get_buck2_root().unwrap_or_exit();
         buck2_root.join("buckal.toml").into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RepoConfig;
+
+    #[test]
+    fn test_repo_config_deserializes_version_patch() {
+        let config: RepoConfig = toml::from_str(
+            r#"
+                [patch.version]
+                pyo3 = { from = "0.26.0", to = "0.27.2" }
+            "#,
+        )
+        .expect("failed to deserialize repo config");
+
+        let patch = config
+            .patch
+            .version
+            .get("pyo3")
+            .expect("missing pyo3 patch");
+
+        assert_eq!(patch.from, "0.26.0");
+        assert_eq!(patch.to, "0.27.2");
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -114,6 +114,7 @@ impl BuckalContext {
                 matches!(candidate.kind, NodeKind::ThirdParty)
                     && candidate.name == node.name
                     && candidate.version == version_patch.to
+                    && candidate.source == node.source
             })
             .collect();
 
@@ -130,5 +131,142 @@ impl BuckalContext {
                 version_patch.to
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{RepoPatchConfig, VersionPatch};
+    use crate::resolve::{BuckalDep, BuckalNode, BuckalResolve, NodeKind};
+    use cargo_metadata::Edition;
+    use daggy::Dag;
+
+    fn make_node_with_source(name: &str, version: &str, source: Option<&str>) -> BuckalNode {
+        BuckalNode {
+            package_id: PackageId {
+                repr: format!(
+                    "{}#{}@{}",
+                    source.unwrap_or("path+file:///local"),
+                    name,
+                    version
+                ),
+            },
+            name: name.to_string(),
+            version: version.to_string(),
+            features: vec![],
+            kind: NodeKind::ThirdParty,
+            edition: Edition::E2021,
+            manifest_path: Utf8PathBuf::from(format!("/tmp/{}/Cargo.toml", name)),
+            targets: vec![],
+            source: source.map(String::from),
+            links: None,
+            checksum: None,
+        }
+    }
+
+    fn make_context(resolve: BuckalResolve, patch: RepoPatchConfig) -> BuckalContext {
+        BuckalContext {
+            root: None,
+            resolve,
+            workspace_root: Utf8PathBuf::from("/tmp"),
+            workspace_inherit: false,
+            no_merge: false,
+            repo_config: RepoConfig {
+                patch,
+                ..RepoConfig::default()
+            },
+        }
+    }
+
+    /// When the same crate name/version exists from two different sources (e.g.
+    /// crates.io and git), `patched_node` must select the candidate that matches
+    /// the original node's source, not bail with "ambiguous".
+    #[test]
+    fn test_patched_node_disambiguates_by_source() {
+        let registry = "registry+https://github.com/rust-lang/crates.io-index";
+        let git = "git+https://github.com/example/foo.git";
+
+        let from_registry = make_node_with_source("foo", "1.0.0", Some(registry));
+        let to_registry = make_node_with_source("foo", "2.0.0", Some(registry));
+        let to_git = make_node_with_source("foo", "2.0.0", Some(git));
+
+        let mut dag = Dag::<BuckalNode, BuckalDep, u32>::new();
+        let mut index_map = HashMap::new();
+
+        let idx_from = dag.add_node(from_registry.clone());
+        let idx_to_reg = dag.add_node(to_registry.clone());
+        let idx_to_git = dag.add_node(to_git.clone());
+
+        index_map.insert(from_registry.package_id.clone(), idx_from);
+        index_map.insert(to_registry.package_id.clone(), idx_to_reg);
+        index_map.insert(to_git.package_id.clone(), idx_to_git);
+
+        let resolve = BuckalResolve { dag, index_map };
+
+        let patch = RepoPatchConfig {
+            version: [(
+                "foo".to_string(),
+                VersionPatch {
+                    from: "1.0.0".to_string(),
+                    to: "2.0.0".to_string(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+
+        let ctx = make_context(resolve, patch);
+        let result = ctx.patched_node(&from_registry).unwrap();
+
+        // Must select the registry candidate, not the git one
+        assert_eq!(result.source.as_deref(), Some(registry));
+        assert_eq!(result.version, "2.0.0");
+    }
+
+    /// When the target version does not exist for the same source,
+    /// `patched_node` should return an error even if another source has it.
+    #[test]
+    fn test_patched_node_missing_when_wrong_source() {
+        let registry = "registry+https://github.com/rust-lang/crates.io-index";
+        let git = "git+https://github.com/example/foo.git";
+
+        let from_registry = make_node_with_source("foo", "1.0.0", Some(registry));
+        // Only the git source has version 2.0.0
+        let to_git = make_node_with_source("foo", "2.0.0", Some(git));
+
+        let mut dag = Dag::<BuckalNode, BuckalDep, u32>::new();
+        let mut index_map = HashMap::new();
+
+        let idx_from = dag.add_node(from_registry.clone());
+        let idx_to_git = dag.add_node(to_git.clone());
+
+        index_map.insert(from_registry.package_id.clone(), idx_from);
+        index_map.insert(to_git.package_id.clone(), idx_to_git);
+
+        let resolve = BuckalResolve { dag, index_map };
+
+        let patch = RepoPatchConfig {
+            version: [(
+                "foo".to_string(),
+                VersionPatch {
+                    from: "1.0.0".to_string(),
+                    to: "2.0.0".to_string(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+
+        let ctx = make_context(resolve, patch);
+        let result = ctx.patched_node(&from_registry);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing dependency version")
+        );
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
+use anyhow::{Result, bail};
 use cargo_metadata::{MetadataCommand, PackageId, camino::Utf8PathBuf};
 use cargo_util_schemas::{lockfile::TomlLockfile, manifest::TomlManifest};
 
 use crate::{
     config::RepoConfig,
-    resolve::BuckalResolve,
+    resolve::{BuckalNode, BuckalResolve, NodeKind},
     utils::{UnwrapOrExit, get_buck2_root},
 };
 
@@ -90,6 +91,44 @@ impl BuckalContext {
             workspace_inherit,
             no_merge: false,
             repo_config,
+        }
+    }
+
+    pub fn patched_node<'a>(&'a self, node: &'a BuckalNode) -> Result<&'a BuckalNode> {
+        if !matches!(node.kind, NodeKind::ThirdParty) {
+            return Ok(node);
+        }
+
+        let Some(version_patch) = self.repo_config.patch.version.get(&node.name) else {
+            return Ok(node);
+        };
+
+        if version_patch.from != node.version {
+            return Ok(node);
+        }
+
+        let candidates: Vec<&BuckalNode> = self
+            .resolve
+            .nodes()
+            .filter(|candidate| {
+                matches!(candidate.kind, NodeKind::ThirdParty)
+                    && candidate.name == node.name
+                    && candidate.version == version_patch.to
+            })
+            .collect();
+
+        match candidates.as_slice() {
+            [patched] => Ok(*patched),
+            [] => bail!(
+                "version patch for '{}' points to missing dependency version '{}'",
+                node.name,
+                version_patch.to
+            ),
+            _ => bail!(
+                "version patch for '{}' is ambiguous for version '{}'",
+                node.name,
+                version_patch.to
+            ),
         }
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -467,8 +467,10 @@ impl BuckalResolve {
         // 10. Version patch config for child dependencies — if any direct child
         //     is affected by a version patch, include that patch in the parent's
         //     fingerprint so dependents are invalidated when patches change.
-        for (_, node_idx) in self.dag.children(idx).iter(&self.dag) {
-            let child_node = &self.dag[node_idx];
+        //     Reuse the already-sorted `children` list for deterministic hashing.
+        for (_, edge_idx) in &children {
+            let (_, child_idx) = self.dag.edge_endpoints(*edge_idx).unwrap();
+            let child_node = &self.dag[child_idx];
             if let Some(vp) = patch_config.version.get(&child_node.name) {
                 hasher.update(b"child_version_patch");
                 hasher.update(child_node.name.as_bytes());
@@ -1257,6 +1259,82 @@ mod tests {
         assert_eq!(
             fp_alice, fp_bob,
             "fingerprints should be portable across checkout locations"
+        );
+    }
+
+    /// Child version patches must produce the same fingerprint regardless of the
+    /// order children are inserted into the DAG, since step 10 should iterate
+    /// the already-sorted child list.
+    #[test]
+    fn test_child_patch_fingerprint_stable_across_insertion_order() {
+        let patch_config = RepoPatchConfig {
+            version: [
+                (
+                    "alpha".to_string(),
+                    crate::config::VersionPatch {
+                        from: "1.0.0".to_string(),
+                        to: "2.0.0".to_string(),
+                    },
+                ),
+                (
+                    "beta".to_string(),
+                    crate::config::VersionPatch {
+                        from: "1.0.0".to_string(),
+                        to: "3.0.0".to_string(),
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        };
+
+        // Graph 1: insert alpha before beta
+        let mut dag1 = Dag::<BuckalNode, BuckalDep, u32>::new();
+        let mut map1 = HashMap::new();
+        let parent1 = make_node("parent", "1.0.0");
+        let alpha1 = make_node("alpha", "1.0.0");
+        let beta1 = make_node("beta", "1.0.0");
+        let idx_p1 = dag1.add_node(parent1.clone());
+        let idx_a1 = dag1.add_node(alpha1.clone());
+        let idx_b1 = dag1.add_node(beta1.clone());
+        map1.insert(parent1.package_id.clone(), idx_p1);
+        map1.insert(alpha1.package_id.clone(), idx_a1);
+        map1.insert(beta1.package_id.clone(), idx_b1);
+        dag1.add_edge(idx_p1, idx_a1, make_dep("alpha")).unwrap();
+        dag1.add_edge(idx_p1, idx_b1, make_dep("beta")).unwrap();
+        let resolve1 = BuckalResolve {
+            dag: dag1,
+            index_map: map1,
+        };
+
+        // Graph 2: insert beta before alpha (reversed insertion order)
+        let mut dag2 = Dag::<BuckalNode, BuckalDep, u32>::new();
+        let mut map2 = HashMap::new();
+        let parent2 = make_node("parent", "1.0.0");
+        let beta2 = make_node("beta", "1.0.0");
+        let alpha2 = make_node("alpha", "1.0.0");
+        let idx_p2 = dag2.add_node(parent2.clone());
+        let idx_b2 = dag2.add_node(beta2.clone());
+        let idx_a2 = dag2.add_node(alpha2.clone());
+        map2.insert(parent2.package_id.clone(), idx_p2);
+        map2.insert(beta2.package_id.clone(), idx_b2);
+        map2.insert(alpha2.package_id.clone(), idx_a2);
+        // Add edges in reversed order
+        dag2.add_edge(idx_p2, idx_b2, make_dep("beta")).unwrap();
+        dag2.add_edge(idx_p2, idx_a2, make_dep("alpha")).unwrap();
+        let resolve2 = BuckalResolve {
+            dag: dag2,
+            index_map: map2,
+        };
+
+        let fp1 =
+            resolve1.fingerprint_of(&parent1.package_id, &test_workspace_root(), &patch_config);
+        let fp2 =
+            resolve2.fingerprint_of(&parent2.package_id, &test_workspace_root(), &patch_config);
+
+        assert_eq!(
+            fp1, fp2,
+            "child patch fingerprints must be stable regardless of DAG insertion order"
         );
     }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -7,6 +7,7 @@ use daggy::{Dag, NodeIndex, Walker};
 use serde::{Deserialize, Serialize};
 
 use crate::cache::{Fingerprint, PackageIdExt};
+use crate::config::RepoPatchConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeKind {
@@ -347,7 +348,12 @@ impl BuckalResolve {
     /// `workspace_root` is used to canonicalize `PackageId` values for path dependencies
     /// so that the same project checked out at different locations produces identical
     /// fingerprints.
-    pub fn fingerprint_of(&self, pkg_id: &PackageId, workspace_root: &Utf8PathBuf) -> Fingerprint {
+    pub fn fingerprint_of(
+        &self,
+        pkg_id: &PackageId,
+        workspace_root: &Utf8PathBuf,
+        patch_config: &RepoPatchConfig,
+    ) -> Fingerprint {
         let idx = self.index_map[pkg_id];
         let node = &self.dag[idx];
         let mut hasher = blake3::Hasher::new();
@@ -447,6 +453,28 @@ impl BuckalResolve {
                     .expect("Serialization failed");
             hasher.update(&dep_encoded);
             hasher.update(child_canonical_id.repr.as_bytes());
+        }
+
+        // 9. Version patch config — if a patch references this node's crate name,
+        //    include it so adding/changing/removing a patch invalidates both the
+        //    "from" and "to" version nodes plus their dependents (via edge hashing).
+        if let Some(vp) = patch_config.version.get(&node.name) {
+            hasher.update(b"version_patch");
+            hasher.update(vp.from.as_bytes());
+            hasher.update(vp.to.as_bytes());
+        }
+
+        // 10. Version patch config for child dependencies — if any direct child
+        //     is affected by a version patch, include that patch in the parent's
+        //     fingerprint so dependents are invalidated when patches change.
+        for (_, node_idx) in self.dag.children(idx).iter(&self.dag) {
+            let child_node = &self.dag[node_idx];
+            if let Some(vp) = patch_config.version.get(&child_node.name) {
+                hasher.update(b"child_version_patch");
+                hasher.update(child_node.name.as_bytes());
+                hasher.update(vp.from.as_bytes());
+                hasher.update(vp.to.as_bytes());
+            }
         }
 
         Fingerprint::new(hasher.finalize().into())
@@ -618,14 +646,30 @@ mod tests {
 
         // Same data -> same fingerprint
         assert_eq!(
-            resolve1.fingerprint_of(&node1.package_id, &test_workspace_root()),
-            resolve2.fingerprint_of(&node2.package_id, &test_workspace_root())
+            resolve1.fingerprint_of(
+                &node1.package_id,
+                &test_workspace_root(),
+                &RepoPatchConfig::default()
+            ),
+            resolve2.fingerprint_of(
+                &node2.package_id,
+                &test_workspace_root(),
+                &RepoPatchConfig::default()
+            )
         );
 
         // Different version -> different fingerprint
         assert_ne!(
-            resolve1.fingerprint_of(&node1.package_id, &test_workspace_root()),
-            resolve3.fingerprint_of(&node3.package_id, &test_workspace_root())
+            resolve1.fingerprint_of(
+                &node1.package_id,
+                &test_workspace_root(),
+                &RepoPatchConfig::default()
+            ),
+            resolve3.fingerprint_of(
+                &node3.package_id,
+                &test_workspace_root(),
+                &RepoPatchConfig::default()
+            )
         );
     }
 
@@ -740,8 +784,16 @@ mod tests {
 
         // Fingerprints of common@1.0.0 and common@2.0.0 must differ
         assert_ne!(
-            resolve.fingerprint_of(&common_v1_id, &test_workspace_root()),
-            resolve.fingerprint_of(&common_v2_id, &test_workspace_root()),
+            resolve.fingerprint_of(
+                &common_v1_id,
+                &test_workspace_root(),
+                &RepoPatchConfig::default()
+            ),
+            resolve.fingerprint_of(
+                &common_v2_id,
+                &test_workspace_root(),
+                &RepoPatchConfig::default()
+            ),
             "different versions should produce different fingerprints"
         );
     }
@@ -892,9 +944,21 @@ mod tests {
             index_map: index_map3,
         };
 
-        let fp1 = resolve1.fingerprint_of(&make_pkg_id("a"), &test_workspace_root());
-        let fp2 = resolve2.fingerprint_of(&make_pkg_id("a"), &test_workspace_root());
-        let fp3 = resolve3.fingerprint_of(&make_pkg_id("a"), &test_workspace_root());
+        let fp1 = resolve1.fingerprint_of(
+            &make_pkg_id("a"),
+            &test_workspace_root(),
+            &RepoPatchConfig::default(),
+        );
+        let fp2 = resolve2.fingerprint_of(
+            &make_pkg_id("a"),
+            &test_workspace_root(),
+            &RepoPatchConfig::default(),
+        );
+        let fp3 = resolve3.fingerprint_of(
+            &make_pkg_id("a"),
+            &test_workspace_root(),
+            &RepoPatchConfig::default(),
+        );
 
         // Adding a dep changes the fingerprint
         assert_ne!(
@@ -906,6 +970,48 @@ mod tests {
         assert_ne!(
             fp2, fp3,
             "different edge metadata should change the fingerprint"
+        );
+    }
+
+    /// Adding a version patch for a child dependency should change the parent's
+    /// fingerprint, so that dependents are invalidated when patches change.
+    #[test]
+    fn test_version_patch_on_child_invalidates_parent_fingerprint() {
+        let mut dag = Dag::new();
+        let mut index_map = HashMap::new();
+        let parent = make_node("parent", "1.0.0");
+        let child = make_node("child", "1.0.0");
+        let idx_parent = dag.add_node(parent.clone());
+        let idx_child = dag.add_node(child.clone());
+        index_map.insert(parent.package_id.clone(), idx_parent);
+        index_map.insert(child.package_id.clone(), idx_child);
+        dag.add_edge(idx_parent, idx_child, make_dep("child"))
+            .unwrap();
+        let resolve = BuckalResolve { dag, index_map };
+
+        let fp_no_patch = resolve.fingerprint_of(
+            &parent.package_id,
+            &test_workspace_root(),
+            &RepoPatchConfig::default(),
+        );
+
+        let patch_config = RepoPatchConfig {
+            version: [(
+                "child".to_string(),
+                crate::config::VersionPatch {
+                    from: "1.0.0".to_string(),
+                    to: "2.0.0".to_string(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+        let fp_with_patch =
+            resolve.fingerprint_of(&parent.package_id, &test_workspace_root(), &patch_config);
+
+        assert_ne!(
+            fp_no_patch, fp_with_patch,
+            "adding a version patch for a child dep should change the parent's fingerprint"
         );
     }
 
@@ -1140,8 +1246,13 @@ mod tests {
                 repr: "path+file:///home/alice/project#foo@1.0.0".to_string(),
             },
             &alice_root,
+            &RepoPatchConfig::default(),
         );
-        let fp_bob = resolve2.fingerprint_of(&node_alice.package_id, &bob_root);
+        let fp_bob = resolve2.fingerprint_of(
+            &node_alice.package_id,
+            &bob_root,
+            &RepoPatchConfig::default(),
+        );
 
         assert_eq!(
             fp_alice, fp_bob,
@@ -1205,8 +1316,8 @@ mod tests {
             index_map: map2,
         };
 
-        let fp1 = resolve1.fingerprint_of(&node1.package_id, &root1);
-        let fp2 = resolve2.fingerprint_of(&node2.package_id, &root2);
+        let fp1 = resolve1.fingerprint_of(&node1.package_id, &root1, &RepoPatchConfig::default());
+        let fp2 = resolve2.fingerprint_of(&node2.package_id, &root2, &RepoPatchConfig::default());
 
         assert_eq!(
             fp1, fp2,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -455,23 +455,29 @@ impl BuckalResolve {
             hasher.update(child_canonical_id.repr.as_bytes());
         }
 
-        // 9. Version patch config — if a patch references this node's crate name,
-        //    include it so adding/changing/removing a patch invalidates both the
-        //    "from" and "to" version nodes plus their dependents (via edge hashing).
-        if let Some(vp) = patch_config.version.get(&node.name) {
+        // 9. Version patch config — if a patch references this node's crate name
+        //    AND this node's version matches the patch's "from" or "to", include
+        //    the patch so that only the affected version nodes (and their dependents
+        //    via edge hashing) are invalidated when patches change.
+        if let Some(vp) = patch_config.version.get(&node.name)
+            && (node.version == vp.from || node.version == vp.to)
+        {
             hasher.update(b"version_patch");
             hasher.update(vp.from.as_bytes());
             hasher.update(vp.to.as_bytes());
         }
 
         // 10. Version patch config for child dependencies — if any direct child
-        //     is affected by a version patch, include that patch in the parent's
-        //     fingerprint so dependents are invalidated when patches change.
+        //     is affected by a version patch (i.e. the child's version matches the
+        //     patch's "from" or "to"), include that patch in the parent's fingerprint
+        //     so dependents are invalidated when patches change.
         //     Reuse the already-sorted `children` list for deterministic hashing.
         for (_, edge_idx) in &children {
             let (_, child_idx) = self.dag.edge_endpoints(*edge_idx).unwrap();
             let child_node = &self.dag[child_idx];
-            if let Some(vp) = patch_config.version.get(&child_node.name) {
+            if let Some(vp) = patch_config.version.get(&child_node.name)
+                && (child_node.version == vp.from || child_node.version == vp.to)
+            {
                 hasher.update(b"child_version_patch");
                 hasher.update(child_node.name.as_bytes());
                 hasher.update(vp.from.as_bytes());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -545,7 +545,7 @@ pub fn get_last_cache(manifest_path: Option<&str>) -> BuckalCache {
                 return BuckalCache::new_empty();
             }
         };
-        BuckalCache::from_resolve(&resolve, &metadata.workspace_root)
+        BuckalCache::from_resolve(&resolve, &metadata.workspace_root, &crate::config::RepoPatchConfig::default())
     })
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -545,8 +545,25 @@ pub fn get_last_cache(manifest_path: Option<&str>) -> BuckalCache {
                 return BuckalCache::new_empty();
             }
         };
-        BuckalCache::from_resolve(&resolve, &metadata.workspace_root, &crate::config::RepoPatchConfig::default())
+        let repo_patch_config = load_repo_patch_config(&metadata.workspace_root);
+        BuckalCache::from_resolve(&resolve, &metadata.workspace_root, &repo_patch_config)
     })
+}
+
+/// Load the patch config from `buckal.toml` at the given workspace root,
+/// falling back to defaults if the file is missing or unparsable.
+fn load_repo_patch_config(
+    workspace_root: &cargo_metadata::camino::Utf8PathBuf,
+) -> crate::config::RepoPatchConfig {
+    let config_path = workspace_root.join("buckal.toml");
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return crate::config::RepoPatchConfig::default(),
+    };
+    match toml::from_str::<crate::config::RepoConfig>(&content) {
+        Ok(c) => c.patch,
+        Err(_) => crate::config::RepoPatchConfig::default(),
+    }
 }
 
 /// Read checksums from Cargo.lock, returning an empty map if the file is missing or unparsable.

--- a/tests/resolve_dag.rs
+++ b/tests/resolve_dag.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
+use cargo_buckal::buck::Rule;
+use cargo_buckal::buckify::buckify_root_node;
 use cargo_buckal::cache::{BuckalCache, ChangeType};
+use cargo_buckal::config::{RepoConfig, RepoPatchConfig, VersionPatch};
+use cargo_buckal::context::BuckalContext;
 use cargo_buckal::resolve::{BuckalNode, BuckalResolve, NodeKind};
 use cargo_metadata::camino::Utf8PathBuf;
 use cargo_metadata::{MetadataCommand, PackageId};
@@ -131,6 +135,7 @@ fn test_dag_first_party_demo() {
     let cache = BuckalCache::from_resolve(
         &resolve,
         &cargo_metadata::camino::Utf8PathBuf::from("/tmp/buckal-test/first-party-demo"),
+        &RepoPatchConfig::default(),
     );
     // Verify cache has entries for all nodes
     let cache_str = toml::to_string_pretty(&cache).unwrap();
@@ -216,6 +221,7 @@ fn test_dag_monorepo_demo() {
     let cache = BuckalCache::from_resolve(
         &resolve,
         &cargo_metadata::camino::Utf8PathBuf::from("/tmp/buckal-test/monorepo-demo/project"),
+        &RepoPatchConfig::default(),
     );
     let cache_str = toml::to_string_pretty(&cache).unwrap();
     assert!(
@@ -313,8 +319,8 @@ fn test_dag_fd_find() {
 
     // Cache construction and fingerprint determinism
     let ws_root = cargo_metadata::camino::Utf8PathBuf::from("/tmp/buckal-test/fd");
-    let cache1 = BuckalCache::from_resolve(&resolve, &ws_root);
-    let cache2 = BuckalCache::from_resolve(&resolve, &ws_root);
+    let cache1 = BuckalCache::from_resolve(&resolve, &ws_root, &RepoPatchConfig::default());
+    let cache2 = BuckalCache::from_resolve(&resolve, &ws_root, &RepoPatchConfig::default());
     let s1 = toml::to_string_pretty(&cache1).unwrap();
     let s2 = toml::to_string_pretty(&cache2).unwrap();
     assert_eq!(
@@ -472,8 +478,16 @@ fn test_diamond_deps_version_conflict() {
     // Fingerprints of the two itoa versions must differ
     let ws_root = Utf8PathBuf::from("/tmp");
     assert_ne!(
-        resolve.fingerprint_of(&itoa_old_node.package_id, &ws_root),
-        resolve.fingerprint_of(&itoa_new_node.package_id, &ws_root),
+        resolve.fingerprint_of(
+            &itoa_old_node.package_id,
+            &ws_root,
+            &RepoPatchConfig::default()
+        ),
+        resolve.fingerprint_of(
+            &itoa_new_node.package_id,
+            &ws_root,
+            &RepoPatchConfig::default()
+        ),
         "different itoa versions should have different fingerprints"
     );
 
@@ -523,11 +537,101 @@ fn test_diamond_deps_version_conflict() {
     let fixture_dir =
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/diamond-deps");
     let ws_root = cargo_metadata::camino::Utf8PathBuf::from(fixture_dir.to_str().unwrap());
-    let cache = BuckalCache::from_resolve(&resolve, &ws_root);
+    let cache = BuckalCache::from_resolve(&resolve, &ws_root, &RepoPatchConfig::default());
     let cache_str = toml::to_string_pretty(&cache).unwrap();
     assert!(
         cache_str.contains("fingerprints"),
         "cache should contain fingerprints section"
+    );
+}
+
+#[test]
+fn test_patch_redirects_generated_dependency_label() {
+    let resolve = resolve_from_fixture("diamond-deps");
+
+    let old_crate = resolve
+        .find_by_name("uses-itoa-old", None)
+        .expect("uses-itoa-old not found")
+        .clone();
+
+    let mut itoa_nodes: Vec<&BuckalNode> = resolve.nodes().filter(|n| n.name == "itoa").collect();
+    assert_eq!(
+        itoa_nodes.len(),
+        2,
+        "expected exactly two resolved itoa versions"
+    );
+    itoa_nodes.sort_by(|a, b| a.version.cmp(&b.version));
+
+    let from_version = itoa_nodes[0].version.clone();
+    let to_version = itoa_nodes[1].version.clone();
+    let from_label = format!("//third-party/rust/crates/itoa/{from_version}:itoa");
+    let to_label = format!("//third-party/rust/crates/itoa/{to_version}:itoa");
+
+    let fixture_dir =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/diamond-deps");
+    let workspace_root = Utf8PathBuf::from(fixture_dir.to_str().unwrap());
+
+    let base_ctx = BuckalContext {
+        root: Some(old_crate.package_id.clone()),
+        resolve,
+        workspace_root,
+        workspace_inherit: false,
+        no_merge: false,
+        repo_config: RepoConfig::default(),
+    };
+
+    let unpatched_rules = buckify_root_node(&old_crate, &base_ctx);
+    let unpatched_lib = unpatched_rules
+        .iter()
+        .find_map(|rule| match rule {
+            Rule::RustLibrary(rule) => Some(rule),
+            _ => None,
+        })
+        .expect("missing rust_library rule for uses-itoa-old");
+    assert!(
+        unpatched_lib.deps.contains(&from_label),
+        "expected original dependency label {from_label}, got {:?}",
+        unpatched_lib.deps
+    );
+    assert!(
+        !unpatched_lib.deps.contains(&to_label),
+        "unpatched rules should not reference {to_label}"
+    );
+
+    let patched_ctx = BuckalContext {
+        repo_config: RepoConfig {
+            patch: RepoPatchConfig {
+                version: [(
+                    "itoa".to_string(),
+                    VersionPatch {
+                        from: from_version.clone(),
+                        to: to_version.clone(),
+                    },
+                )]
+                .into_iter()
+                .collect(),
+            },
+            ..RepoConfig::default()
+        },
+        ..base_ctx
+    };
+
+    let patched_rules = buckify_root_node(&old_crate, &patched_ctx);
+    let patched_lib = patched_rules
+        .iter()
+        .find_map(|rule| match rule {
+            Rule::RustLibrary(rule) => Some(rule),
+            _ => None,
+        })
+        .expect("missing patched rust_library rule for uses-itoa-old");
+    assert!(
+        patched_lib.deps.contains(&to_label),
+        "expected patched dependency label {to_label}, got {:?}",
+        patched_lib.deps
+    );
+    assert!(
+        !patched_lib.deps.contains(&from_label),
+        "patched rules should no longer reference {from_label}"
     );
 }
 
@@ -791,7 +895,7 @@ fn test_resolve_without_lockfile() {
 
     // Cache construction should work despite missing checksums
     let ws_root = cargo_metadata::camino::Utf8PathBuf::from(tmp.path().to_str().unwrap());
-    let cache = BuckalCache::from_resolve(&resolve, &ws_root);
+    let cache = BuckalCache::from_resolve(&resolve, &ws_root, &RepoPatchConfig::default());
     let cache_str = toml::to_string_pretty(&cache).unwrap();
     assert!(
         cache_str.contains("fingerprints"),
@@ -818,10 +922,12 @@ fn test_fallback_cache_honors_manifest_path() {
     let cache_a = BuckalCache::from_resolve(
         &fixture_a,
         &cargo_metadata::camino::Utf8PathBuf::from(ws_a.to_str().unwrap()),
+        &RepoPatchConfig::default(),
     );
     let cache_b = BuckalCache::from_resolve(
         &fixture_b,
         &cargo_metadata::camino::Utf8PathBuf::from(ws_b.to_str().unwrap()),
+        &RepoPatchConfig::default(),
     );
 
     let str_a = toml::to_string_pretty(&cache_a).unwrap();
@@ -880,10 +986,12 @@ fn test_empty_cache_loses_removals() {
     let old_cache = BuckalCache::from_resolve(
         &old_resolve,
         &cargo_metadata::camino::Utf8PathBuf::from(ws_old.to_str().unwrap()),
+        &RepoPatchConfig::default(),
     );
     let new_cache = BuckalCache::from_resolve(
         &new_resolve,
         &cargo_metadata::camino::Utf8PathBuf::from(ws_new.to_str().unwrap()),
+        &RepoPatchConfig::default(),
     );
     let empty_cache = BuckalCache::new_empty();
 


### PR DESCRIPTION
## Summary
- add `cargo buckal patch <DEP>[@<VERSION>]` and persist version remaps in `buckal.toml`
- apply repo patch config during BUCK dependency emission so patched edges redirect to the selected resolved version
- add integration coverage using the diamond-deps fixture to verify generated labels switch to the patched dependency version

## Testing
- cargo test