### PR TITLE
Fix/workspace canonicalize windows pathfmt

### DIFF
--- a/src/buckify/actions.rs
+++ b/src/buckify/actions.rs
@@ -8,7 +8,7 @@ use crate::{
     cache::{BuckalChange, ChangeType},
     context::BuckalContext,
     resolve::{BuckalNode, NodeKind},
-    utils::{UnwrapOrExit, get_vendor_dir},
+    utils::{UnwrapOrExit, get_vendor_dir, is_path_source},
 };
 
 use super::{
@@ -20,7 +20,6 @@ impl BuckalChange {
     pub fn apply(&self, ctx: &BuckalContext) {
         let re: Regex = Regex::new(r"^([^+#]+)\+([^#]+)#([^@]+)@([^+#]+)(?:\+(.+))?$")
             .expect("error creating regex");
-        let skip_pattern = format!("path+file://{}", ctx.workspace_root);
 
         let mut workspace_emitted = false;
 
@@ -79,8 +78,12 @@ impl BuckalChange {
                     }
                 }
                 ChangeType::Removed => {
-                    // Skip workspace_root package
-                    if id.repr.starts_with(skip_pattern.as_str()) {
+                    // Path-source packages (the workspace root, its members, and any
+                    // local `path = "..."` dep) live in the user's source tree, not in
+                    // a vendor directory, so there is nothing for us to remove. Skip
+                    // them; get_vendor_dir would otherwise abort on the unsupported
+                    // source kind.
+                    if is_path_source(id).unwrap_or_exit_ctx("failed to classify package source") {
                         continue;
                     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,11 +17,16 @@ use crate::resolve::BuckalResolve;
 /// Version 2: Added multi-platform support to the cache format.
 /// Version 3: Switched to BuckalNode-based fingerprinting (DAG refactor).
 /// Version 4: Include version patch config in fingerprints.
+/// Version 5: Canonicalized workspace-internal path-source PackageIds to the
+///            `($WORKSPACE)` `file://`-URL form. Pre-v5 caches stored the
+///            absolute workspace path verbatim (always so on Windows, where
+///            canonicalization used to no-op), so diffing an older cache against a
+///            v5-format snapshot would report spurious add/remove entries.
 ///
 /// Migration strategy:
 /// - If found < expected (stale cache from older Buckal): ignore the old cache and rebuild.
 /// - If found > expected (cache from newer Buckal): exit immediately and prompt the user to upgrade.
-const CACHE_VERSION: u32 = 4;
+const CACHE_VERSION: u32 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Fingerprint([u8; 32]);
@@ -61,6 +66,33 @@ pub trait BuckalHash {
     fn fingerprint(&self) -> Fingerprint;
 }
 
+/// Placeholder written into `buckal.snap` in place of the absolute workspace
+/// root, so the cache file is portable across checkouts at different paths.
+const WORKSPACE_ID_PLACEHOLDER: &str = "path+file://($WORKSPACE)";
+
+/// The `path+file://…` package-id prefix Cargo emits for crates under
+/// `workspace_root`.
+///
+/// `cargo metadata` reports `workspace_root` as a native filesystem path, but
+/// path-source package ids embed it as a `file://` URL — forward slashes, a
+/// leading slash before a Windows drive letter, percent-encoding for characters
+/// like spaces. Building the prefix via [`url::Url::from_file_path`], the same
+/// conversion Cargo itself uses, keeps the two in lockstep on every platform
+/// (the previous hand-rolled substring match silently failed on Windows and on
+/// any path containing escaped characters).
+fn workspace_id_prefix(workspace_root: &Utf8PathBuf) -> String {
+    let url = url::Url::from_file_path(workspace_root.as_std_path())
+        .expect("workspace_root from `cargo metadata` is always an absolute path");
+    format!("path+{url}")
+}
+
+/// Whether `rest` — what follows a workspace-root prefix in a package-id repr —
+/// is a real boundary (a subpath `/…` or the version tag `#…`) rather than the
+/// prefix merely being a substring of a sibling directory's path.
+fn is_id_boundary(rest: &str) -> bool {
+    rest.starts_with('/') || rest.starts_with('#')
+}
+
 pub trait PackageIdExt {
     /// ($WORKSPACE) → workspace_root
     fn resolve(&self, workspace_root: &Utf8PathBuf) -> Self;
@@ -71,31 +103,21 @@ pub trait PackageIdExt {
 
 impl PackageIdExt for PackageId {
     fn resolve(&self, workspace_root: &Utf8PathBuf) -> Self {
-        if self.repr.starts_with("path+file://($WORKSPACE)") {
-            PackageId {
-                repr: self
-                    .repr
-                    .clone()
-                    .replace("($WORKSPACE)", workspace_root.as_str()),
-            }
-        } else {
-            self.clone()
+        match self.repr.strip_prefix(WORKSPACE_ID_PLACEHOLDER) {
+            Some(rest) if is_id_boundary(rest) => PackageId {
+                repr: format!("{}{rest}", workspace_id_prefix(workspace_root)),
+            },
+            _ => self.clone(),
         }
     }
 
     fn canonicalize(&self, workspace_root: &Utf8PathBuf) -> Self {
-        if self
-            .repr
-            .starts_with(format!("path+file://{}", workspace_root.as_str()).as_str())
-        {
-            PackageId {
-                repr: self
-                    .repr
-                    .clone()
-                    .replace(workspace_root.as_str(), "($WORKSPACE)"),
-            }
-        } else {
-            self.clone()
+        let prefix = workspace_id_prefix(workspace_root);
+        match self.repr.strip_prefix(prefix.as_str()) {
+            Some(rest) if is_id_boundary(rest) => PackageId {
+                repr: format!("{WORKSPACE_ID_PLACEHOLDER}{rest}"),
+            },
+            _ => self.clone(),
         }
     }
 }
@@ -350,12 +372,12 @@ mod tests {
 
     #[test]
     fn cache_version_bumped_for_workspace_pathfmt_change() {
-        // Pre-v4 caches store absolute path-crate keys (verbatim on Windows); v4
-        // stores the ($WORKSPACE) form. The version bump forces a rebuild instead
-        // of a misdiff between the two representations on first run after upgrade.
-        assert!(
-            CACHE_VERSION >= 4,
-            "CACHE_VERSION must be bumped when the workspace path-id format changes"
-        );
+        // v5 is the bump for ($WORKSPACE) path-id canonicalization: pre-v5 caches
+        // store the absolute workspace path verbatim (always so on Windows), so an
+        // older cache must be rebuilt rather than diffed against the v5 form. Pinned
+        // exactly — not `>=` — so a future bump is a deliberate, visible event:
+        // when you bump CACHE_VERSION, update this assertion and add the rationale
+        // to the CACHE_VERSION doc comment.
+        assert_eq!(CACHE_VERSION, 5);
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -206,3 +206,156 @@ pub enum ChangeType {
     Removed,
     Changed,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{CACHE_VERSION, PackageIdExt};
+    use cargo_metadata::{PackageId, camino::Utf8PathBuf};
+
+    // `cargo metadata` reports `workspace_root` as a *native* filesystem path,
+    // but a path-source package id embeds it as the body of a `file://` *URL*:
+    // forward slashes throughout, a leading slash before a Windows drive letter,
+    // and percent-encoding for characters like spaces. `canonicalize` / `resolve`
+    // must bridge the two so `buckal.snap` stores the path-independent
+    // `($WORKSPACE)` placeholder. On Unix a simple absolute path happens to equal
+    // its URL body, so the bug only surfaces on Windows — except for paths
+    // containing characters cargo percent-encodes (`C:\Users\Jane Doe\…`), which
+    // break the bare-substring approach on every platform.
+    //
+    // The shapes below are picked per host because `url::Url::from_file_path`
+    // (used by the fix, and by Cargo itself) only accepts a path that is
+    // absolute *on the current OS*.
+
+    fn ws() -> Utf8PathBuf {
+        if cfg!(windows) {
+            Utf8PathBuf::from(r"D:\proj")
+        } else {
+            Utf8PathBuf::from("/work/proj")
+        }
+    }
+
+    /// The `path+file://…` prefix Cargo emits for path crates under [`ws`].
+    fn ws_prefix() -> &'static str {
+        if cfg!(windows) {
+            "path+file:///D:/proj"
+        } else {
+            "path+file:///work/proj"
+        }
+    }
+
+    fn ws_spaced() -> Utf8PathBuf {
+        if cfg!(windows) {
+            Utf8PathBuf::from(r"D:\Code\Jane Doe\proj")
+        } else {
+            Utf8PathBuf::from("/work/Jane Doe/proj")
+        }
+    }
+
+    fn ws_spaced_prefix() -> &'static str {
+        if cfg!(windows) {
+            "path+file:///D:/Code/Jane%20Doe/proj"
+        } else {
+            "path+file:///work/Jane%20Doe/proj"
+        }
+    }
+
+    #[test]
+    fn canonicalize_workspace_internal_path_crate() {
+        let id = PackageId {
+            repr: format!("{}/crates/foo#0.1.0", ws_prefix()),
+        };
+        assert_eq!(
+            id.canonicalize(&ws()).repr,
+            "path+file://($WORKSPACE)/crates/foo#0.1.0",
+            "a path crate under the workspace root must be rewritten to ($WORKSPACE)"
+        );
+    }
+
+    #[test]
+    fn resolve_reproduces_cargo_metadata_repr() {
+        let canon = PackageId {
+            repr: "path+file://($WORKSPACE)/crates/foo#0.1.0".to_string(),
+        };
+        assert_eq!(
+            canon.resolve(&ws()).repr,
+            format!("{}/crates/foo#0.1.0", ws_prefix()),
+            "resolve must reproduce the exact repr `cargo metadata` emits"
+        );
+    }
+
+    #[test]
+    fn canonicalize_handles_workspace_root_package_itself() {
+        let id = PackageId {
+            repr: format!("{}#0.7.0", ws_prefix()),
+        };
+        assert_eq!(
+            id.canonicalize(&ws()).repr,
+            "path+file://($WORKSPACE)#0.7.0"
+        );
+    }
+
+    #[test]
+    fn canonicalize_handles_percent_encoded_workspace_path() {
+        // A workspace under a directory whose name contains a space: Cargo
+        // percent-encodes it in the package id, so a literal substring match on
+        // the native path fails on every platform.
+        let id = PackageId {
+            repr: format!("{}/crates/foo#0.1.0", ws_spaced_prefix()),
+        };
+        assert_eq!(
+            id.canonicalize(&ws_spaced()).repr,
+            "path+file://($WORKSPACE)/crates/foo#0.1.0"
+        );
+        let back = PackageId {
+            repr: "path+file://($WORKSPACE)/crates/foo#0.1.0".to_string(),
+        };
+        assert_eq!(
+            back.resolve(&ws_spaced()).repr,
+            format!("{}/crates/foo#0.1.0", ws_spaced_prefix())
+        );
+    }
+
+    #[test]
+    fn canonicalize_leaves_non_workspace_path_crate_untouched() {
+        // A path dep that lives *outside* the workspace must be left alone — the
+        // ($WORKSPACE) placeholder can't express it. Guards against over-reach.
+        let outside = if cfg!(windows) {
+            "path+file:///D:/other/lib/bar#0.1.0"
+        } else {
+            "path+file:///work/other/lib/bar#0.1.0"
+        };
+        let id = PackageId {
+            repr: outside.to_string(),
+        };
+        assert_eq!(id.canonicalize(&ws()).repr, id.repr);
+    }
+
+    #[test]
+    fn canonicalize_leaves_registry_id_untouched() {
+        let id = PackageId {
+            repr: "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0".to_string(),
+        };
+        assert_eq!(id.canonicalize(&ws()).repr, id.repr);
+    }
+
+    #[test]
+    fn canonicalize_does_not_match_sibling_directory() {
+        // `<root>` must not be matched as a bare substring of a sibling directory
+        // that merely shares a name prefix (`proj` vs `proj_sidecar`).
+        let id = PackageId {
+            repr: format!("{}_sidecar/lib/bar#0.1.0", ws_prefix()),
+        };
+        assert_eq!(id.canonicalize(&ws()).repr, id.repr);
+    }
+
+    #[test]
+    fn cache_version_bumped_for_workspace_pathfmt_change() {
+        // Pre-v4 caches store absolute path-crate keys (verbatim on Windows); v4
+        // stores the ($WORKSPACE) form. The version bump forces a rebuild instead
+        // of a misdiff between the two representations on first run after upgrade.
+        assert!(
+            CACHE_VERSION >= 4,
+            "CACHE_VERSION must be bumped when the workspace path-id format changes"
+        );
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -156,7 +156,10 @@ impl BuckalCache {
         }
     }
 
-    pub fn load() -> Result<Self, Error> {
+    /// Read and parse the on-disk cache, exiting if it was written by a newer
+    /// Buckal. The returned cache may still be a stale (older) version — callers
+    /// decide whether to reject or migrate it.
+    fn read_from_disk() -> Result<Self, Error> {
         let cache_path = get_cache_path().unwrap_or_exit_ctx("failed to get cache path");
         if !cache_path.exists() {
             return Err(anyhow!("Cache file does not exist"));
@@ -172,6 +175,11 @@ impl BuckalCache {
             );
             std::process::exit(1);
         }
+        Ok(cache)
+    }
+
+    pub fn load() -> Result<Self, Error> {
+        let cache = Self::read_from_disk()?;
         if cache.version < CACHE_VERSION {
             return Err(anyhow!(
                 "Cache version is stale (found {}, expected {})",
@@ -180,6 +188,53 @@ impl BuckalCache {
             ));
         }
         Ok(cache)
+    }
+
+    /// Like [`load`](Self::load), but upgrades an older-but-migratable cache in
+    /// place instead of rejecting it.
+    ///
+    /// A bare `load()` returns `Err` on any stale version, which `migrate`
+    /// turns into [`new_empty`](Self::new_empty) — and an empty `last` cache
+    /// reports nothing as `Removed`, leaving orphaned BUCK targets behind on a
+    /// version bump. `migrate` cannot fall back to rebuilding the prior state
+    /// from `cargo metadata` (the way add/remove/update do) because there is no
+    /// pending manifest edit: current metadata already equals the new state, so
+    /// removed packages are simply absent from it.
+    ///
+    /// The v4→v5 bump only changed how workspace path-source `PackageId`s are
+    /// keyed (verbatim absolute path → `($WORKSPACE)`), not the struct layout,
+    /// so we can preserve removal detection by re-keying the old fingerprints
+    /// with the fixed canonicalizer. Fingerprint *values* are kept as-is; any
+    /// that no longer match a freshly computed snapshot just re-emit as
+    /// `Changed`, which is safe (and on Windows actively rewrites BUCK files
+    /// that had embedded an absolute path).
+    pub fn load_migrated(workspace_root: &Utf8PathBuf) -> Result<Self, Error> {
+        let cache = Self::read_from_disk()?;
+        if cache.version == CACHE_VERSION {
+            return Ok(cache);
+        }
+        if cache.version == 4 {
+            return Ok(cache.rekeyed_v4_to_v5(workspace_root));
+        }
+        Err(anyhow!(
+            "Cache version is stale and not migratable (found {}, expected {})",
+            cache.version,
+            CACHE_VERSION
+        ))
+    }
+
+    /// Re-key a v4 cache's fingerprints to the v5 `($WORKSPACE)` form. v5 only
+    /// changed key canonicalization, so the package set is preserved verbatim —
+    /// which is what keeps `diff()` reporting `Removed` across the bump.
+    fn rekeyed_v4_to_v5(self, workspace_root: &Utf8PathBuf) -> Self {
+        Self {
+            fingerprints: self
+                .fingerprints
+                .into_iter()
+                .map(|(id, fp)| (id.canonicalize(workspace_root), fp))
+                .collect(),
+            version: CACHE_VERSION,
+        }
     }
 
     pub fn save(&self) {
@@ -379,5 +434,60 @@ mod tests {
         // when you bump CACHE_VERSION, update this assertion and add the rationale
         // to the CACHE_VERSION doc comment.
         assert_eq!(CACHE_VERSION, 5);
+    }
+
+    #[test]
+    fn migrating_v4_cache_preserves_removal_detection() {
+        use super::{BuckalCache, ChangeType, Fingerprint};
+        use std::collections::BTreeMap;
+
+        // A v4 snapshot as written on Windows: workspace path-source ids stored
+        // with the absolute path verbatim (the pre-v5 canonicalize no-op).
+        let foo_abs = PackageId {
+            repr: format!("{}/crates/foo#0.1.0", ws_prefix()),
+        };
+        let bar_abs = PackageId {
+            repr: format!("{}/crates/bar#0.1.0", ws_prefix()),
+        };
+        let mut v4 = BTreeMap::new();
+        v4.insert(foo_abs.clone(), Fingerprint::new([1u8; 32]));
+        v4.insert(bar_abs.clone(), Fingerprint::new([2u8; 32]));
+        let v4_cache = BuckalCache {
+            fingerprints: v4,
+            version: 4,
+        };
+
+        // The new resolve dropped `bar` from the manifest; its keys are v5-canonical.
+        let foo_canon = foo_abs.canonicalize(&ws());
+        let mut v5 = BTreeMap::new();
+        v5.insert(foo_canon.clone(), Fingerprint::new([1u8; 32]));
+        let new_cache = BuckalCache {
+            fingerprints: v5,
+            version: CACHE_VERSION,
+        };
+
+        let migrated = v4_cache.rekeyed_v4_to_v5(&ws());
+        let changes = new_cache.diff(&migrated, &ws());
+
+        // `bar` must be reported as Removed. Discarding the stale cache (the old
+        // new_empty() path) would silently keep its orphaned BUCK target — the
+        // regression Codex flagged.
+        let bar_resolved = bar_abs.canonicalize(&ws()).resolve(&ws());
+        assert!(
+            matches!(
+                changes.changes.get(&bar_resolved),
+                Some(ChangeType::Removed)
+            ),
+            "removed workspace crate must be detected as Removed after v4->v5 migration; got {:?}",
+            changes.changes
+        );
+        // `foo` is unchanged (same fingerprint, key now aligned), so the
+        // migration introduces no spurious diff entry for it.
+        let foo_resolved = foo_canon.resolve(&ws());
+        assert!(
+            !changes.changes.contains_key(&foo_resolved),
+            "unchanged crate must not appear in the diff after migration; got {:?}",
+            changes.changes
+        );
     }
 }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -114,13 +114,16 @@ pub fn execute(args: &MigrateArgs) {
     ctx.no_merge = !args.merge;
 
     // Process dep nodes
-    // For migrate, a missing/stale cache means "first run" — use empty so everything
-    // is treated as Added and BUCK files are generated from scratch. This differs from
-    // add/remove/update which use get_last_cache() to rebuild from metadata for diffing.
-    let last_cache = if args.no_cache || BuckalCache::load().is_err() {
+    // For migrate, a missing cache means "first run" — use empty so everything is
+    // treated as Added and BUCK files are generated from scratch. A stale-but-
+    // migratable cache (e.g. a v4 snapshot after the v5 path-id bump) is upgraded
+    // in place rather than discarded, so packages dropped from the manifest are
+    // still detected as Removed. This differs from add/remove/update, which use
+    // get_last_cache() to rebuild the prior state from metadata before the edit.
+    let last_cache = if args.no_cache {
         BuckalCache::new_empty()
     } else {
-        BuckalCache::load().unwrap_or_exit_ctx("failed to load existing cache")
+        BuckalCache::load_migrated(&ctx.workspace_root).unwrap_or_else(|_| BuckalCache::new_empty())
     };
     let new_cache =
         BuckalCache::from_resolve(&ctx.resolve, &ctx.workspace_root, &ctx.repo_config.patch);

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -492,9 +492,35 @@ impl BuckalResolve {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use url::Url;
+
+    // Synthetic fixture paths that are absolute *on the host OS*, so they
+    // round-trip through `Url::from_file_path` the way a real `workspace_root`
+    // from `cargo metadata` does. (These fixtures previously used POSIX-only
+    // literals like `/tmp` and `/home/alice/project`, which aren't absolute on
+    // Windows and so can't be turned into a `file://` URL there.)
+    #[cfg(windows)]
+    const FIXTURE_BASE: &str = r"C:\buckal-fixture";
+    #[cfg(not(windows))]
+    const FIXTURE_BASE: &str = "/buckal-fixture";
+
+    fn fixture_path(rel: &str) -> Utf8PathBuf {
+        let mut p = Utf8PathBuf::from(FIXTURE_BASE);
+        p.push(rel);
+        p
+    }
+
+    /// A synthetic checkout location plus the `path+file://…` package-id prefix
+    /// Cargo emits for crates under it: `(native_root, id_prefix)`.
+    fn checkout(rel: &str) -> (Utf8PathBuf, String) {
+        let root = fixture_path(rel);
+        let url =
+            Url::from_file_path(root.as_std_path()).expect("fixture path must be host-absolute");
+        (root, format!("path+{url}"))
+    }
 
     fn test_workspace_root() -> Utf8PathBuf {
-        Utf8PathBuf::from("/tmp")
+        fixture_path("workspace")
     }
 
     fn make_pkg_id(name: &str) -> PackageId {
@@ -523,7 +549,7 @@ mod tests {
             features: vec![],
             kind: NodeKind::ThirdParty,
             edition: Edition::E2021,
-            manifest_path: Utf8PathBuf::from(format!("/tmp/{}/Cargo.toml", name)),
+            manifest_path: fixture_path(name).join("Cargo.toml"),
             targets: vec![],
             source: Some("registry+https://github.com/rust-lang/crates.io-index".to_string()),
             links: None,
@@ -1197,70 +1223,50 @@ mod tests {
     /// First-party nodes at different checkout locations should produce identical fingerprints.
     #[test]
     fn test_fingerprint_portable_across_paths() {
-        // Node checked out at /home/alice/project
-        let alice_root = Utf8PathBuf::from("/home/alice/project");
-        let mut node_alice = BuckalNode {
-            package_id: PackageId {
-                repr: "path+file:///home/alice/project#foo@1.0.0".to_string(),
-            },
-            name: "foo".to_string(),
-            version: "1.0.0".to_string(),
-            features: vec![],
-            kind: NodeKind::FirstParty {
-                relative_path: "".to_string(),
-            },
-            edition: Edition::E2021,
-            manifest_path: Utf8PathBuf::from("/home/alice/project/Cargo.toml"),
-            targets: vec![BuckalTarget {
+        // The same first-party crate, checked out at two different locations,
+        // must fingerprint identically (the workspace prefix is stripped to
+        // `($WORKSPACE)` and `src_path` is relativized against the manifest dir).
+        fn build(root: &Utf8PathBuf, id_prefix: &str) -> (BuckalResolve, PackageId) {
+            let pkg_id = PackageId {
+                repr: format!("{id_prefix}#foo@1.0.0"),
+            };
+            let node = BuckalNode {
+                package_id: pkg_id.clone(),
                 name: "foo".to_string(),
-                kind: vec![TargetKind::Lib],
-                src_path: Utf8PathBuf::from("/home/alice/project/src/lib.rs"),
-                doctest: true,
-                test: true,
-            }],
-            source: None,
-            links: None,
-            checksum: None,
-        };
+                version: "1.0.0".to_string(),
+                features: vec![],
+                kind: NodeKind::FirstParty {
+                    relative_path: String::new(),
+                },
+                edition: Edition::E2021,
+                manifest_path: root.join("Cargo.toml"),
+                targets: vec![BuckalTarget {
+                    name: "foo".to_string(),
+                    kind: vec![TargetKind::Lib],
+                    src_path: root.join("src").join("lib.rs"),
+                    doctest: true,
+                    test: true,
+                }],
+                source: None,
+                links: None,
+                checksum: None,
+            };
+            let mut dag = Dag::<BuckalNode, BuckalDep, u32>::new();
+            let mut index_map = HashMap::new();
+            let idx = dag.add_node(node);
+            index_map.insert(pkg_id.clone(), idx);
+            (BuckalResolve { dag, index_map }, pkg_id)
+        }
 
-        let mut dag1 = Dag::<BuckalNode, BuckalDep, u32>::new();
-        let mut map1 = HashMap::new();
-        let idx1 = dag1.add_node(node_alice.clone());
-        map1.insert(node_alice.package_id.clone(), idx1);
-        let resolve1 = BuckalResolve {
-            dag: dag1,
-            index_map: map1,
-        };
+        let (alice_root, alice_prefix) = checkout("alice/project");
+        let (bob_root, bob_prefix) = checkout("bob/work/project");
 
-        // Same node checked out at /home/bob/work/project
-        let bob_root = Utf8PathBuf::from("/home/bob/work/project");
-        node_alice.package_id = PackageId {
-            repr: "path+file:///home/bob/work/project#foo@1.0.0".to_string(),
-        };
-        node_alice.manifest_path = Utf8PathBuf::from("/home/bob/work/project/Cargo.toml");
-        node_alice.targets[0].src_path = Utf8PathBuf::from("/home/bob/work/project/src/lib.rs");
+        let (resolve_alice, id_alice) = build(&alice_root, &alice_prefix);
+        let (resolve_bob, id_bob) = build(&bob_root, &bob_prefix);
 
-        let mut dag2 = Dag::<BuckalNode, BuckalDep, u32>::new();
-        let mut map2 = HashMap::new();
-        let idx2 = dag2.add_node(node_alice.clone());
-        map2.insert(node_alice.package_id.clone(), idx2);
-        let resolve2 = BuckalResolve {
-            dag: dag2,
-            index_map: map2,
-        };
-
-        let fp_alice = resolve1.fingerprint_of(
-            &PackageId {
-                repr: "path+file:///home/alice/project#foo@1.0.0".to_string(),
-            },
-            &alice_root,
-            &RepoPatchConfig::default(),
-        );
-        let fp_bob = resolve2.fingerprint_of(
-            &node_alice.package_id,
-            &bob_root,
-            &RepoPatchConfig::default(),
-        );
+        let fp_alice =
+            resolve_alice.fingerprint_of(&id_alice, &alice_root, &RepoPatchConfig::default());
+        let fp_bob = resolve_bob.fingerprint_of(&id_bob, &bob_root, &RepoPatchConfig::default());
 
         assert_eq!(
             fp_alice, fp_bob,
@@ -1379,8 +1385,8 @@ mod tests {
             (node, Utf8PathBuf::from(format!("{}/project", cargo_home)))
         };
 
-        let (node1, root1) = make_third_party("/home/alice");
-        let (node2, root2) = make_third_party("/home/bob");
+        let (node1, root1) = make_third_party(fixture_path("alice").as_str());
+        let (node2, root2) = make_third_party(fixture_path("bob").as_str());
 
         let mut dag1 = Dag::<BuckalNode, BuckalDep, u32>::new();
         let mut map1 = HashMap::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -485,6 +485,20 @@ pub fn get_vendor_dir(package_id: &PackageId) -> Result<Utf8PathBuf> {
     Ok(get_buck2_root()?.join(get_vendor_path_relative(package_id)?))
 }
 
+/// Whether a package id refers to a local path source — a workspace member or
+/// any `path = "..."` dependency.
+///
+/// Such packages live in the user's own source tree, not in a vendor
+/// directory, so buckal never vendors or removes them ([`get_vendor_dir`]
+/// rejects them as an unsupported source kind). Callers classify removals this
+/// way rather than string-matching the workspace-root prefix, which is fragile:
+/// a path-source id embeds the root as a `file://` URL (forward slashes,
+/// percent-encoding), not the native path.
+pub fn is_path_source(package_id: &PackageId) -> Result<bool> {
+    let spec = PackageIdSpec::parse(&package_id.repr)?;
+    Ok(matches!(spec.kind(), Some(SourceKind::Path)))
+}
+
 /// Retrieve the last saved BuckalCache from the cache file, or rebuild from metadata if unavailable.
 ///
 /// `manifest_path` should match the `--manifest-path` argument passed to the command,
@@ -691,6 +705,46 @@ mod tests {
         assert!(!is_valid_rustc_target(""));
         assert!(!is_valid_rustc_target("x86_64"));
         assert!(!is_valid_rustc_target("linux"));
+    }
+
+    #[test]
+    fn test_is_path_source_classifies_removed_ids() {
+        // URL-form path ids — what `PackageId::resolve` now produces. These are
+        // exactly the shapes the old native-path `skip_pattern` failed to match.
+        assert!(
+            is_path_source(&PackageId {
+                repr: "path+file:///C:/repo#0.1.0".to_string(),
+            })
+            .unwrap()
+        );
+        assert!(
+            is_path_source(&PackageId {
+                repr: "path+file:///C:/repo/crates/foo#0.1.0".to_string(),
+            })
+            .unwrap()
+        );
+        // A workspace path that needs percent-encoding (space in a dir name).
+        assert!(
+            is_path_source(&PackageId {
+                repr: "path+file:///C:/Code/Jane%20Doe/repo/crates/foo#0.1.0".to_string(),
+            })
+            .unwrap()
+        );
+
+        // Vendorable sources must not be skipped on removal.
+        assert!(
+            !is_path_source(&PackageId {
+                repr: "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0"
+                    .to_string(),
+            })
+            .unwrap()
+        );
+        assert!(
+            !is_path_source(&PackageId {
+                repr: "git+https://github.com/foo/bar?rev=abc#bar@0.1.0".to_string(),
+            })
+            .unwrap()
+        );
     }
 
     #[test]

--- a/tests/resolve_dag.rs
+++ b/tests/resolve_dag.rs
@@ -476,7 +476,12 @@ fn test_diamond_deps_version_conflict() {
     assert!(found_new.version.starts_with("1."));
 
     // Fingerprints of the two itoa versions must differ
-    let ws_root = Utf8PathBuf::from("/tmp");
+    let ws_root = Utf8PathBuf::from(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/diamond-deps")
+            .to_str()
+            .unwrap(),
+    );
     assert_ne!(
         resolve.fingerprint_of(
             &itoa_old_node.package_id,


### PR DESCRIPTION
Addresses #101 

This raises the question for consideration for a Windows CI job as well, though I'm guessing linux is the usual target. Buck2 makes cross-platform easier, so would make Windows CI actions a good nice to have.